### PR TITLE
Mrevow/backbone

### DIFF
--- a/audioDataset.py
+++ b/audioDataset.py
@@ -26,6 +26,9 @@ class AudioDataset(torch.utils.data.Dataset):
             "train",
             "val",
             "test",
+            "suptrain",
+            "supval",
+            "suptest",
         ], "Split '{}' not supported for AudioDataset".format(mode)
         self.mode = mode
         self.test = True if mode == 'test' else False

--- a/audioTransformer.py
+++ b/audioTransformer.py
@@ -3,7 +3,7 @@ import torch
 from torchaudio import transforms as torchAudioTransforms 
 import barlowtwins.audioTransforms as localTransforms
 
-class AudioTransformer(object):
+class AudioTransformer(nn.Module):
   '''
   Creates transformers for the BarlowTwins network.
   An input audio tensor is transformed twice for each pathway in the network
@@ -14,6 +14,7 @@ class AudioTransformer(object):
   arguments is a dict of argName: value  that will be accepted by the transform
   '''
   def __init__(self, args, logger):
+    super().__init__()
     self.args = args
     self.logger = logger
 
@@ -60,6 +61,7 @@ class AudioTransformerBatch(AudioTransformer):
   arguments is a dict of argName: value  that will be accepted by the transform
   '''
   def __init__(self, args, logger):
+    super().__init__(args, logger)
     self.args = args
     self.logger = logger
 

--- a/audioTransforms.py
+++ b/audioTransforms.py
@@ -49,7 +49,7 @@ class LibrPitch(nn.Module):
     x = lb.effects.pitch_shift(x.numpy(), sr=self.sr, n_steps=shift)
     return torch.tensor(x)
 
-###################### Batch Transofrms #################################
+###################### Batch Transforms #################################
 class NormalizeInputBatch(nn.Module):
   def __init__(self, chanCount, transpose=None, biasInit=0.0, weightinit=1.0):
     '''

--- a/azure/hack.yaml
+++ b/azure/hack.yaml
@@ -1,6 +1,6 @@
 _include: !include hackBase.yaml
 
-epochs: 2
+epochs: 50
 music_classifier_epochs: 50
 batch_size: 1024
 data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1/', 'hack/music-detection-data/music-detection-unlabeled/']  # relative path to the binary data files

--- a/azure/hack.yaml
+++ b/azure/hack.yaml
@@ -1,18 +1,28 @@
 _include: !include hackBase.yaml
 
-epochs: 20
-batch_size: 256
+epochs: 75
+batch_size: 1024
 data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1/', 'hack/music-detection-data/music-detection-unlabeled/']  # relative path to the binary data files
 data_train_view_files: ['hack/trainConfigs/train_unsupervised.txt', 'hack/trainConfigs/music_notLabeled_16572_10secOnly.txt']   # relative path to the train view file lists
 print_freq: 50
 plot_freq: 5
 debug: True
+# data_suptrain_bin_path: ['hack/music-detection-data/sl_training_set_v1']  # relative path to the binary data files
+# data_supval_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised only
 
-backbone_model: Cnn6
+print_freq: 100
+
+# operations: ['train_unsupervised', 'train_supervised', 'eval_supervised']
+# operations: [ 'train_supervised']
+# operations: ['data_ops']
+# data_ops: ['clipListByDir', ]
+# data_analysis_outputfile: data.log
+
+music_classifier_epochs: 20
 
 # To use a torchvision Net
-# backbone_model: resnet18
-# backbone_kwargs: [{ "zero_init_residual": True}]
+backbone_model: resnet18
+backbone_kwargs: [{ "zero_init_residual": True}]
 
 data_plot_min_limits: {'loss': 0.0}
 data_plot_max_limits: {'loss': 12000.0}

--- a/azure/hack.yaml
+++ b/azure/hack.yaml
@@ -1,24 +1,27 @@
 _include: !include hackBase.yaml
 
-epochs: 75
+epochs: 2
+music_classifier_epochs: 50
 batch_size: 1024
 data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1/', 'hack/music-detection-data/music-detection-unlabeled/']  # relative path to the binary data files
 data_train_view_files: ['hack/trainConfigs/train_unsupervised.txt', 'hack/trainConfigs/music_notLabeled_16572_10secOnly.txt']   # relative path to the train view file lists
 print_freq: 50
 plot_freq: 5
-debug: True
-# data_suptrain_bin_path: ['hack/music-detection-data/sl_training_set_v1']  # relative path to the binary data files
-# data_supval_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised only
 
-print_freq: 100
+# For short tests
+# data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1']  # relative path to the binary data files
+# data_train_view_files: ['hack/trainConfigs/short_40.txt']   # relative path to the train view file lists
+# data_suptrain_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised training
+# data_suptrain_view_files: ['hack/trainConfigs/short_40.txt']    # supervised training
+# data_supval_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised val (during train)
+# data_supval_view_files: ['hack/trainConfigs/short_40.txt']    # supervised val (during train)
+# data_supval_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised val (during train
+# data_suptest_view_files: ['hack/trainConfigs/short_40.txt']    # supervised eval run
+# data_suptest_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised eval run)
 
-# operations: ['train_unsupervised', 'train_supervised', 'eval_supervised']
-# operations: [ 'train_supervised']
-# operations: ['data_ops']
-# data_ops: ['clipListByDir', ]
-# data_analysis_outputfile: data.log
 
-music_classifier_epochs: 20
+operations: ['train_unsupervised', 'train_supervised', 'eval_supervised']
+
 
 # To use a torchvision Net
 backbone_model: resnet18

--- a/azure/hackBase.yaml
+++ b/azure/hackBase.yaml
@@ -18,19 +18,27 @@ early_stop_patience: 10 # supervised only
 projector: '8192-8192-8192'  # Projector MLP
 print_freq: 10000
 plot_freq: 100
-checkpoint_dir: checkpoint
-checkpoint_name: checkpoint.pth
+checkpoint_name: barlow_checkpoint.pth
 backend: nccl
 master_port: '9756'
 backbone_model: Cnn6
 backbone_kwargs: [{'sample_rate': 16000, 'window_size': 1024, 'hop_size': 800, 'mel_bins': 64, 'fmin': 0, 'fmax': 8000, 'classes_num': 2 }]
 learning_rate: 0.0001 # learning rate for supervised training
 
+music_classifier_freeze_backbone: false
+music_classifier_epochs: 100
+music_classifier_checkpoint_name: music_checkpoint.pth
+
 # Data
-data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1/']  # relative path to the binary data files
-data_train_view_files: ['hack/trainConfigs/all.txt']   # relative path to the train view file lists
-data_val_bin_path: ['hack/music-detection-data/sl_training_set_v1/'] # supervised only
-data_val_view_files: ['hack/trainConfigs/supervised_val_v02.txt']    # supervised only
+data_train_bin_path: ['hack/music-detection-data/sl_training_set_v1']  # relative path to the binary data files
+data_train_view_files: ['hack/trainConfigs/train_unsupervised.txt']   # relative path to the train view file lists
+
+data_suptrain_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised training
+data_suptrain_view_files: ['hack/trainConfigs/supervised_train_v02.txt']    # supervised training
+data_supval_bin_path: ['hack/music-detection-data/sl_training_set_v1'] # supervised val (during train)
+data_supval_view_files: ['hack/trainConfigs/supervised_val_v02.txt']    # supervised val (during train)
+data_suptest_bin_path: ['hack/music-detection-data/test_set'] # supervised eval run
+data_suptest_view_files: ['hack/trainConfigs/test.txt']    # supervised eval run
 
 data_num_retry: 10 # Maximum number of retries when  clip cannot be loaded
 data_samp_rate: 16000

--- a/azure/run.py
+++ b/azure/run.py
@@ -88,7 +88,7 @@ def main():
             musicClassifier.eval()
 
           else:
-            raise ValueError('operation {} not found'.format(op))
+            raise ValueError('operation {} not found expect one of [train_unsupervised, train_supervised, eval_supervised'.format(op))
 
 if __name__ == "__main__":
   main()

--- a/azure/vqm_environment_cpu.yaml
+++ b/azure/vqm_environment_cpu.yaml
@@ -15,7 +15,7 @@ dependencies:
   - torchlibrosa
   - torchvision
   - torchaudio  
-  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634246896.882089-py3-none-any.whl
+  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634266328.8444865-py3-none-any.whl
   - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/ic3_ai-0.13-py3-none-any.whl
 - pytorch
 - cpuonly

--- a/azure/vqm_environment_cpu.yaml
+++ b/azure/vqm_environment_cpu.yaml
@@ -15,7 +15,7 @@ dependencies:
   - torchlibrosa
   - torchvision
   - torchaudio  
-  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634266328.8444865-py3-none-any.whl
+  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634323538.6821887-py3-none-any.whl
   - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/ic3_ai-0.13-py3-none-any.whl
 - pytorch
 - cpuonly

--- a/azure/vqm_environment_gpu.yaml
+++ b/azure/vqm_environment_gpu.yaml
@@ -16,7 +16,7 @@ dependencies:
   - torchlibrosa
   - torchvision
   - torchaudio
-  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634266328.8444865-py3-none-any.whl
+  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634323538.6821887-py3-none-any.whl
   - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/ic3_ai-0.13-py3-none-any.whl
 - pytorch
 - cudatoolkit=10.1

--- a/azure/vqm_environment_gpu.yaml
+++ b/azure/vqm_environment_gpu.yaml
@@ -16,7 +16,7 @@ dependencies:
   - torchlibrosa
   - torchvision
   - torchaudio
-  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634246896.882089-py3-none-any.whl
+  - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/barlow-1634266328.8444865-py3-none-any.whl
   - https://pstntrain2380840354.blob.core.windows.net/azureml/Environment/azureml-private-packages/ic3_ai-0.13-py3-none-any.whl
 - pytorch
 - cudatoolkit=10.1

--- a/musicClassification.py
+++ b/musicClassification.py
@@ -214,7 +214,7 @@ def load_checkpoint(args, logger, model, checkpoint_name):
 
         ckpt['model'] = updateCheckPointKeys(ckpt['model'])
         if torch.cuda.is_available() and torch.cuda.device_count()>1:
-            [missing_keys, unexpected_keys ]  = model.load_state_dict(ckpt['model'], strict=False)
+            [missing_keys, unexpected_keys ]  = model.module.load_state_dict(ckpt['model'], strict=False)
         else:
             [missing_keys, unexpected_keys ]  = model.load_state_dict(ckpt['model'], strict=False)
 

--- a/musicClassification.py
+++ b/musicClassification.py
@@ -111,7 +111,7 @@ def train(args, logger):
     early_stopper = EarlyStopper(args)
 
     start_time = time.time()
-    logger.info('Start musicClassifier training ..')
+    logger.info('Start musicClassifier training for {} epochs'.format(args.music_classifier_epochs))
     for epoch in range(0, args.music_classifier_epochs):
         for step, ((x1, _), y1, _) in enumerate(loader_train, start=epoch * len(loader_train)):
             y1 = y1.type(torch.float).to(dev)
@@ -191,7 +191,7 @@ def eval_validation_set(args, logger):
         shuffle=False,
         drop_last=False,
         )
-    logger.info('Start evaluating ..')
+    logger.info('Start musicClassifier evaluation on {} samples '.format(len(dataset_val)))
     results = evaluate(model, loader_val, dev)
     logger.info('Accuracy {:0.3f}, recall {:0.3f}, precision {:0.3f}, '.format(results['accuracy'], results['recall'], results['precision'],))
     return results
@@ -274,6 +274,7 @@ class musicClassifier(nn.Module):
         
         barlow_model = BarlowTwins(self.args, logger, batchTransforms=batchTransforms)
         self.backbone = barlow_model.backbone
+        self.batchTransforms = batchTransforms
         self.classHead = nn.Linear(barlow_model.lastLayerSize, 1, bias=True)        
 
     def forward(self, x):

--- a/musicClassification.py
+++ b/musicClassification.py
@@ -213,7 +213,10 @@ def load_checkpoint(args, logger, model, checkpoint_name):
                         map_location='cpu')
 
         ckpt['model'] = updateCheckPointKeys(ckpt['model'])
-        [missing_keys, unexpected_keys ]  = model.load_state_dict(ckpt['model'], strict=False)
+        if torch.cuda.is_available() and torch.cuda.device_count()>1:
+            [missing_keys, unexpected_keys ]  = model.load_state_dict(ckpt['model'], strict=False)
+        else:
+            [missing_keys, unexpected_keys ]  = model.load_state_dict(ckpt['model'], strict=False)
 
         pth = str(args.checkpoint_dir / checkpoint_name)
         for missed_key in missing_keys:

--- a/musicClassification.py
+++ b/musicClassification.py
@@ -111,7 +111,7 @@ def train(args, logger):
     early_stopper = EarlyStopper(args)
 
     start_time = time.time()
-    logger.info('Start musicClassifiertraining ..')
+    logger.info('Start musicClassifier training ..')
     for epoch in range(0, args.music_classifier_epochs):
         for step, ((x1, _), y1, _) in enumerate(loader_train, start=epoch * len(loader_train)):
             y1 = y1.type(torch.float).to(dev)
@@ -167,7 +167,12 @@ def train(args, logger):
 
 def eval_validation_set(args, logger):
     logger.info("Start musicClassifier supervised evaluation")
-    model =  musicClassifier(args, logger)
+    if args.data_batch_transforms_1 is not None and args.data_batch_transforms_2 is not None:
+        batchTransforms = AudioTransformerBatch(args, logger)
+    else:
+        batchTransforms = None
+
+    model =  musicClassifier(args, logger, batchTransforms)
     logger.info('Loaded music classifier model')
     logger.debug(model)
 


### PR DESCRIPTION
Enable chaining unsupervised with supervised training 
New .yaml fields
Separate view and paths for Supervised train / valid and test
data_supt{train|val|test}_bin_path
data_sup{train|val|test}_view_files

Name the checkpoint files

checkpoint_name - for unsupervised
music_classifier_checkpoint_name  - for supervised

Short run 254